### PR TITLE
Refactoring bug fixes

### DIFF
--- a/src/command.handler.ts
+++ b/src/command.handler.ts
@@ -247,7 +247,8 @@ export function handleCommand(message: string,
         label: realContent,
         done: false,
         colorName: '',
-        colorStyle: null
+        colorStyle: null,
+        fade: false
       };
 
       // option: add newones to the top
@@ -261,7 +262,8 @@ export function handleCommand(message: string,
         label: message,
         done: false,
         colorName: '',
-        colorStyle: null
+        colorStyle: null,
+        fade: false
       };
 
       // option: add newones to the top

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,10 +32,10 @@ export function numberOrDefault(value: number | string, defaultNumber: number) {
 
 export function fillDefaults(currentOptions: QueryOptions): QueryOptions {
   const sanitizedOptions: QueryOptions = {
-    ...currentOptions,
     scrollingInterval: numberOrDefault(currentOptions.scrollingInterval, 5000),
     scrollingDuration: numberOrDefault(currentOptions.scrollingDuration, 2000),
-    layout: 'full'
+    layout: 'full',
+    ...currentOptions
   };
 
 


### PR DESCRIPTION
- query options default fix
Moving the spread operator to the last position should overwrite all the defaults we put ahead of it.

- missing fade property fix
Added a non-optional property to TodoItem but didn't update the command handler file.
We should look at refactoring this big switch file and maybe split out the functionality into smaller files.


