### PR TITLE
Add timer reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Syntax for all other commands: `!COMMAND SUBCOMMAND [ID / TEXT]`
 |`highlight POSITION`|`hl`|Changes all other than `POSITION`  to a lower opacity|
 |`start POSITION`||Starts a timer at `POSITION`|
 |`stop [POSITION]`|| Stops the current timer, or optionally at `POSITION`|
+|`reset [POSITION]`|| Resets the current timer, or optionally at `POSITION`|
 |`cleanup`||Removes all "done" entries|
 
 ## Protips :

--- a/src/command.handler.ts
+++ b/src/command.handler.ts
@@ -1,5 +1,5 @@
 import type { TodoItem } from "./types/item";
-import type { Writable } from "svelte/store";
+import { get, Writable } from "svelte/store";
 import type { TodoList } from "./types/list";
 
 // todo tests
@@ -228,6 +228,30 @@ export function handleCommand(message: string,
         return -1;
       });
 
+
+      break;
+    }
+
+    case "reset": {
+      const [targetIndexStr, ...rest] = realContent.split(' ');
+
+      const targetIndex = stringIdToIndexId(targetIndexStr);
+
+      let currentItemIndex = get(currentTimer);
+      if (currentItemIndex == -1) {
+        currentItemIndex = targetIndex;
+      }
+
+      items.update(curItems => {
+        const currentItem = curItems[currentItemIndex];
+
+        currentItem.spentTime = 0;
+        if (currentItem.startTime) {
+          currentItem.startTime = Date.now();
+        }
+
+        return curItems;
+      });
 
       break;
     }


### PR DESCRIPTION
Adds `reset` command for timers.

Like the `stop` command, it can be provided a position, otherwise it will use the current active timer.

When the timer is running, it resets it back to 0 and it will continue running from there.

When the timer is stopped, it clears the timer entirely.

***

Hopefully I haven't deviated from the existing code style too much.

***

Resolves #28 